### PR TITLE
Heading lines must begin with #

### DIFF
--- a/syntaxes/gemini.tmLanguage.json
+++ b/syntaxes/gemini.tmLanguage.json
@@ -18,7 +18,7 @@
 	"repository": {
 		"headings": {
 			"name": "markup.heading.gemini",
-			"begin": "#",
+			"begin": "^#",
 			"end": "\n"
 		},
 		"raw": {


### PR DESCRIPTION
Currently text like this:

```gemini
To make a heading, use the # character
```

will result in "# character" being a heading, which is incorrect.